### PR TITLE
Avoid pkg_resources for pip package export

### DIFF
--- a/conda_env_export/conda_env_export.py
+++ b/conda_env_export/conda_env_export.py
@@ -7,10 +7,17 @@ from itertools import chain
 from subprocess import Popen, PIPE
 
 import click
-import pkg_resources
 import yaml
 
 flatten = chain.from_iterable
+
+try:
+    from importlib import metadata as importlib_metadata
+except ImportError:
+    try:
+        import importlib_metadata
+    except ImportError:
+        importlib_metadata = None
 
 
 def _dict_representer(dumper, data):
@@ -26,6 +33,64 @@ class CustomDumper(yaml.Dumper):
 
 
 CustomDumper.add_representer(OrderedDict, _dict_representer)
+
+
+class MetadataRequirement(object):
+
+    def __init__(self, requirement):
+        self.key = requirement.name.lower()
+        self.specs = sorted((spec.operator, spec.version)
+                            for spec in requirement.specifier)
+        self.marker = requirement.marker
+
+    def applies(self):
+        if self.marker is None:
+            return True
+        return self.marker.evaluate({'extra': ''})
+
+
+class MetadataPackage(object):
+
+    def __init__(self, distribution):
+        self._distribution = distribution
+        self.project_name = distribution.metadata['Name']
+        self.key = self.project_name.lower()
+        self.version = distribution.version
+
+    def requires(self):
+        try:
+            from packaging.requirements import Requirement
+        except ImportError:
+            raise ImportError(
+                'packaging is required to parse installed requirements')
+
+        requirements = self._distribution.requires or ()
+        parsed = []
+        for requirement in requirements:
+            requirement = MetadataRequirement(Requirement(requirement))
+            if requirement.applies():
+                parsed.append(requirement)
+        return parsed
+
+
+def _iter_pip_packages(paths):
+    if importlib_metadata is not None:
+        try:
+            distributions = importlib_metadata.distributions(path=paths)
+        except TypeError:
+            distributions = importlib_metadata.distributions()
+        return [MetadataPackage(distribution)
+                for distribution in distributions]
+
+    try:
+        import pkg_resources
+    except ImportError:
+        pkg_resources = None
+
+    if pkg_resources is not None:
+        return pkg_resources.working_set
+
+    raise ImportError('importlib.metadata or pkg_resources is required')
 
 
 class Node(object):
@@ -140,7 +205,7 @@ class CondaEnvExport(object):
 
         # Thanks to @https://github.com/ealizadeh-via
         # Fix: https://github.com/luffy-yu/conda_env_export/issues/3
-        pkgs = pkg_resources.working_set
+        pkgs = _iter_pip_packages(paths)
         nodes = {}
         for pkg in pkgs:
             key = pkg.key

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,10 @@ with open('HISTORY.rst') as history_file:
 
 # https://github.com/luffy-yu/conda_env_export/issues/6
 # ruamel.yaml>=0.11.14,<0.18 the front comes from conda, and the rear is to fix deprecated load() function.
-requirements = ['setuptools', 'Click>=7.0', 'cytoolz>=0.11.0', 'PyYAML>=5.1', 'ruamel.yaml>=0.11.14,<0.18',
+requirements = ['Click>=7.0', 'cytoolz>=0.11.0',
+                'importlib-metadata;python_version<"3.8"',
+                'packaging',
+                'PyYAML>=5.1', 'ruamel.yaml>=0.11.14,<0.18',
                 # This works for wheel installation, while dependency_links didn't.
                 # This can not be uploaded to pypi as `Can't have direct dependency`.
                 # Install them via the command, see

--- a/tests/test_conda_env_export.py
+++ b/tests/test_conda_env_export.py
@@ -29,3 +29,36 @@ class TestConda_env_export(unittest.TestCase):
         help_result = runner.invoke(cli.main, ['--help'])
         assert help_result.exit_code == 0
         assert 'Show this message and exit.' in help_result.output
+
+    def test_get_pip_deps_uses_iterated_packages(self):
+        """Test pip export through the package iterator adapter."""
+        class FakeRequirement(object):
+            key = 'dependency'
+            specs = [('>=', '2')]
+
+        class FakePackage(object):
+            def __init__(self, key, version, project_name, requirements=()):
+                self.key = key
+                self.version = version
+                self.project_name = project_name
+                self._requirements = requirements
+
+            def requires(self):
+                return self._requirements
+
+        packages = [
+            FakePackage('root', '1.0', 'Root', [FakeRequirement()]),
+            FakePackage('dependency', '2.0', 'Dependency'),
+        ]
+        original = conda_env_export._iter_pip_packages
+        conda_env_export._iter_pip_packages = lambda paths: packages
+        try:
+            nodes = conda_env_export.CondaEnvExport().get_pip_deps(
+                ['/env/site-packages'], all=True)
+        finally:
+            conda_env_export._iter_pip_packages = original
+
+        assert [str(node) for node in nodes] == [
+            'Dependency==2.0',
+            'Root==1.0',
+        ]


### PR DESCRIPTION
## Summary
- use `importlib.metadata` / `importlib_metadata` to enumerate installed pip distributions when available
- keep the legacy `pkg_resources` path as a lazy fallback for older runtimes
- add runtime dependencies needed for metadata requirement parsing
- cover the pip package export path with a targeted iterator-adapter regression

Fixes #14.

## Validation
- Not run locally