### PR TITLE
Add pip index URL export options

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -60,6 +60,8 @@ To use Conda Env Export in a terminal:
       --include TEXT            Force to include deps (ignore case)
       --exclude TEXT            Force to exclude deps (ignore case)
       --extra-pip-requirements  Output an extra `requirements.txt`  [default: False]
+      --index-url TEXT          Add a pip `--index-url` entry to exported pip requirements
+      --extra-index-url TEXT    Add a pip `--extra-index-url` entry to exported pip requirements
       --no-prefix               Remove `prefix` in target yml file  [default: False]
       --to-folder DIRECTORY     Where to output the file(s)  [default: ./]
       --to-file FILE            Filename of the output yml file  [default: `{activated}`]
@@ -104,6 +106,18 @@ Export current activated env and output an EXTRA pip requirements file, just run
 WHY: Sometimes it'll fail to install some pip deps when executing `conda env create -f env.yml`,
 so it's much more convenient to install pip deps via `pip install -r requirements.txt` rather than
 `conda env update -f env.yml --prune`.
+
+Export current activated env with extra pip package indexes, run:
+
+.. code-block:: console
+
+    $ conda-env-export --extra-index-url https://download.pytorch.org/whl/cu128
+
+You can also provide one primary pip index:
+
+.. code-block:: console
+
+    $ conda-env-export --index-url https://download.pytorch.org/whl/cu128
 
 Export a named env and ensure that output MUST include `pip` and `PyYAML`, run:
 

--- a/conda_env_export/cli.py
+++ b/conda_env_export/cli.py
@@ -16,6 +16,9 @@ from conda_env_export.conda_env_export import CondaEnvExport
 @click.option('--exclude', help='Force to exclude deps (ignore case)', multiple=True)
 @click.option('--extra-pip-requirements', help='Output an extra `requirements.txt`', is_flag=True, default=False,
               show_default=True)
+@click.option('--index-url', help='Add a pip `--index-url` entry to exported pip requirements')
+@click.option('--extra-index-url', help='Add a pip `--extra-index-url` entry to exported pip requirements',
+              multiple=True)
 @click.option('--no-prefix', help='Remove `prefix` in target yml file', is_flag=True, default=False, show_default=True)
 @click.option('--to-folder', help='Where to output the file(s)',
               type=click.Path(exists=True, file_okay=False, dir_okay=True, writable=True),
@@ -24,8 +27,8 @@ from conda_env_export.conda_env_export import CondaEnvExport
               type=click.Path(file_okay=True, dir_okay=False, writable=True),
               default=os.getenv('CONDA_DEFAULT_ENV') + '.yml' if os.getenv('CONDA_DEFAULT_ENV') else '',
               show_default=True)
-def main(name, conda_all, pip_all, separate, reserve_duplicates, include, exclude, extra_pip_requirements, no_prefix,
-         to_folder, to_file):
+def main(name, conda_all, pip_all, separate, reserve_duplicates, include, exclude, extra_pip_requirements, index_url,
+         extra_index_url, no_prefix, to_folder, to_file):
     try:
         include = set(map(lambda x: x.lower(), include))
         exclude = set(map(lambda x: x.lower(), exclude))
@@ -35,7 +38,8 @@ def main(name, conda_all, pip_all, separate, reserve_duplicates, include, exclud
         cee.check(name)
         cee.run(name, conda_all=conda_all, pip_all=pip_all, separate=separate, remove_duplicates=not reserve_duplicates,
                 include=include, exclude=exclude, extra_pip_requirements=extra_pip_requirements, no_prefix=no_prefix,
-                output_folder=to_folder, output_file=to_file)
+                output_folder=to_folder, output_file=to_file, index_url=index_url,
+                extra_index_urls=extra_index_url)
     except AssertionError as e:
         pass
     return 0

--- a/conda_env_export/conda_env_export.py
+++ b/conda_env_export/conda_env_export.py
@@ -63,6 +63,14 @@ class CondaEnvExport(object):
     def __init__(self):
         self.name = 'conda-env-export'
 
+    @staticmethod
+    def pip_index_options(index_url=None, extra_index_urls=()):
+        options = []
+        if index_url:
+            options.append('--index-url %s' % index_url)
+        options.extend('--extra-index-url %s' % url for url in extra_index_urls)
+        return options
+
     @property
     def is_windows(self):
         return sys.platform == 'win32'
@@ -208,7 +216,8 @@ class CondaEnvExport(object):
         nodes = sorted(nodes, key=lambda x: x.key.lower())
         return nodes
 
-    def make_yml(self, conda_nodes, pip_nodes, prefix, name, remove_duplicates=True, no_prefix=False, separate=False):
+    def make_yml(self, conda_nodes, pip_nodes, prefix, name, remove_duplicates=True, no_prefix=False, separate=False,
+                 index_url=None, extra_index_urls=()):
         if remove_duplicates:
             # remove duplicates between conda and pip
             conda_keys = set(map(lambda x: x.key, conda_nodes))
@@ -216,13 +225,14 @@ class CondaEnvExport(object):
 
         func = lambda x: [str(n) for n in x]
         conda_deps = func(conda_nodes)
-        pip_deps = func(pip_nodes)
+        pip_options = self.pip_index_options(index_url=index_url, extra_index_urls=extra_index_urls)
+        pip_deps = pip_options + func(pip_nodes)
 
         dict = OrderedDict()
         dict['name'] = name
         dict['channels'] = sorted(filter(lambda x: len(x), set(map(lambda x: x.channel, conda_nodes))))
         # https://github.com/luffy-yu/conda_env_export/issues/5
-        deps = conda_deps + [{'pip': ['-r requirements.txt'] if separate else pip_deps}]
+        deps = conda_deps + [{'pip': pip_options + ['-r requirements.txt'] if separate else pip_deps}]
         dict['dependencies'] = deps
         if not no_prefix:
             dict['prefix'] = prefix
@@ -301,7 +311,7 @@ class CondaEnvExport(object):
 
     def run(self, name=None, conda_all=False, pip_all=False, separate=False, remove_duplicates=True,
             include=(), exclude=(), extra_pip_requirements=False, no_prefix=False,
-            output_folder=None, output_file=None):
+            output_folder=None, output_file=None, index_url=None, extra_index_urls=()):
 
         click.secho('Exporting......', fg='white')
         try:
@@ -311,7 +321,8 @@ class CondaEnvExport(object):
             pip_paths = self.get_pip_paths(name, conda_prefix)
             pip_nodes = self.get_pip_deps(pip_paths, all=pip_all, include=include, exclude=exclude)
             data, pip_data = self.make_yml(conda_nodes, pip_nodes, conda_prefix, name,
-                                           remove_duplicates=remove_duplicates, no_prefix=no_prefix, separate=separate)
+                                           remove_duplicates=remove_duplicates, no_prefix=no_prefix, separate=separate,
+                                           index_url=index_url, extra_index_urls=extra_index_urls)
 
             # Fix: https://github.com/luffy-yu/conda_env_export/issues/4
             if output_file is None:

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -24,6 +24,8 @@ To use Conda Env Export in a terminal:
       --include TEXT            Force to include deps (ignore case)
       --exclude TEXT            Force to exclude deps (ignore case)
       --extra-pip-requirements  Output an extra `requirements.txt`  [default: False]
+      --index-url TEXT          Add a pip `--index-url` entry to exported pip requirements
+      --extra-index-url TEXT    Add a pip `--extra-index-url` entry to exported pip requirements
       --no-prefix               Remove `prefix` in target yml file  [default: False]
       --to-folder DIRECTORY     Where to output the file(s)  [default: ./]
       --to-file FILE            Filename of the output yml file  [default: `{activated}`]
@@ -68,6 +70,18 @@ Export current activated env and output an EXTRA pip requirements file, just run
 WHY: Sometimes it'll fail to install some pip deps when executing `conda env create -f env.yml`,
 so it's much more convenient to install pip deps via `pip install -r requirements.txt` rather than
 `conda env update -f env.yml --prune`.
+
+Export current activated env with extra pip package indexes, run:
+
+.. code-block:: console
+
+    $ conda-env-export --extra-index-url https://download.pytorch.org/whl/cu128
+
+You can also provide one primary pip index:
+
+.. code-block:: console
+
+    $ conda-env-export --index-url https://download.pytorch.org/whl/cu128
 
 Export a named env and ensure that output MUST include `pip` and `PyYAML`, run:
 

--- a/tests/test_conda_env_export.py
+++ b/tests/test_conda_env_export.py
@@ -29,3 +29,43 @@ class TestConda_env_export(unittest.TestCase):
         help_result = runner.invoke(cli.main, ['--help'])
         assert help_result.exit_code == 0
         assert 'Show this message and exit.' in help_result.output
+
+    def test_make_yml_includes_pip_index_options(self):
+        """Test pip index options are exported with pip requirements."""
+        exporter = conda_env_export.CondaEnvExport()
+        data, pip_data = exporter.make_yml(
+            [conda_env_export.CondaNode('python', '3.11.14', 'defaults')],
+            [conda_env_export.PipNode('torch', '2.8.0+cu128', 'torch')],
+            '/tmp/test-env',
+            'test-env',
+            index_url='https://download.pytorch.org/whl/cu128',
+            extra_index_urls=('https://example.com/simple',),
+        )
+
+        expected_pip_data = [
+            '--index-url https://download.pytorch.org/whl/cu128',
+            '--extra-index-url https://example.com/simple',
+            'torch==2.8.0+cu128',
+        ]
+        assert data['dependencies'][-1] == {'pip': expected_pip_data}
+        assert pip_data == expected_pip_data
+
+    def test_make_yml_includes_pip_index_options_when_separate(self):
+        """Test separate exports keep pip index options in both outputs."""
+        exporter = conda_env_export.CondaEnvExport()
+        data, pip_data = exporter.make_yml(
+            [conda_env_export.CondaNode('python', '3.11.14', 'defaults')],
+            [conda_env_export.PipNode('torch', '2.8.0+cu128', 'torch')],
+            '/tmp/test-env',
+            'test-env',
+            separate=True,
+            extra_index_urls=('https://example.com/simple',),
+        )
+
+        assert data['dependencies'][-1] == {
+            'pip': ['--extra-index-url https://example.com/simple', '-r requirements.txt'],
+        }
+        assert pip_data == [
+            '--extra-index-url https://example.com/simple',
+            'torch==2.8.0+cu128',
+        ]


### PR DESCRIPTION
Summary:
- add `--index-url` and repeatable `--extra-index-url` CLI options
- write pip index options before exported pip packages in YAML and requirements.txt output
- document the new options and add `make_yml` coverage for inline and separate pip exports

Validation:
- `git diff --check`
- `git diff --cached --check`
- `git show --check --stat --oneline HEAD`
- Not run locally.

Closes #12